### PR TITLE
chore: migrate project to pnpm 10.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,23 @@ Kairo is built using the stable Script API:
 ## Requirements
 
 - Node.js (for development and TypeScript build)
+- pnpm 10.31.0
 
 ## Setup && Build
 
+This project bundles scripts with **esbuild** via `build.mjs`.
+
 1. Install dependencies:
     ```bash
-    npm install
+    pnpm install
     ```
 2. Deploy
     ```bash
-    npm run build
+    pnpm run build
     ```
 3. Auto-deploy on file change:
     ```bash
-    npm run dev
+    pnpm run dev
     ```
 
 ## Contributions Welcome!

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "description": "**Stable Script API**\r - @minecraft/server - 2.5.0",
     "main": "index.js",
     "type": "module",
+    "packageManager": "pnpm@10.31.0",
     "scripts": {
         "typecheck": "tsc --noEmit",
-        "build": "rimraf BP/scripts && npm run typecheck && node build.mjs && npm run deploy",
+        "build": "rimraf BP/scripts && pnpm run typecheck && node build.mjs && pnpm run deploy",
         "deploy": "node src/deploy.js"
     },
     "repository": {


### PR DESCRIPTION
### Motivation
- Move the repository from `npm` to `pnpm` as the primary package manager and pin the project to `pnpm@10.31.0` to ensure reproducible installs.
- Clarify in docs that the build step bundles scripts with `esbuild` via `build.mjs` so maintainers know the build toolchain.

### Description
- Add `packageManager: "pnpm@10.31.0"` to `package.json` to pin the package manager version. 
- Change the build pipeline to run internal scripts with `pnpm run` instead of `npm run` in `package.json`. 
- Update `README.md` to replace `npm` usage with `pnpm` instructions, add `pnpm 10.31.0` to the requirements, and note that builds use `esbuild` via `build.mjs`.

### Testing
- Ran `git diff --check`, which produced no issues. 
- Ran `pnpm --version`, which returned the locally-available `10.13.1` in the environment. 
- Attempted `pnpm install`, which failed with registry/proxy `403` due to authorization settings in the environment. 
- Attempted `pnpm run typecheck`, which failed because Corepack could not fetch `pnpm@10.31.0` from the registry due to the same network/authorization restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf9a63eac8333bf6e820f0b7b24f5)