### PR TITLE
feat(ui): AddonDetailScreen の情報表示強化とバージョン切り替えバグ修正

### DIFF
--- a/RP/texts/en_US.lang
+++ b/RP/texts/en_US.lang
@@ -55,6 +55,7 @@ kairo.form.detail.disable=Disable
 kairo.form.detail.latest=Latest Version
 kairo.form.detail.submit=Apply
 kairo.form.detail.deps.none=No dependencies
+kairo.form.detail.developer=Developer
 
 kairo.form.unresolved.title=Unresolved Addon
 kairo.form.unresolved.close=Close

--- a/RP/texts/ja_JP.lang
+++ b/RP/texts/ja_JP.lang
@@ -55,6 +55,7 @@ kairo.form.detail.disable=無効にする
 kairo.form.detail.latest=最新バージョン
 kairo.form.detail.submit=適用
 kairo.form.detail.deps.none=依存関係なし
+kairo.form.detail.developer=開発者向け
 
 kairo.form.unresolved.title=未解決のアドオン
 kairo.form.unresolved.close=閉じる

--- a/src/kairo/activation/ActivationController.ts
+++ b/src/kairo/activation/ActivationController.ts
@@ -68,7 +68,13 @@ export class ActivationController {
         this._world = this.buildWorldState();
         this._world.cachedDeclaredReverseGraph = this.buildReverseGraph(this._world);
         console.log(`[Kairo] Resolution Phase: ${this._world.runtimes.size} addon(s) registered`);
-        const scope = new Set<KairoId>(this._world.runtimes.keys());
+        const scope = new Set<KairoId>();
+        for (const kairoId of this._world.runtimes.keys()) {
+            const registry = this._world.registries.get(kairoId);
+            if (!registry) continue;
+            if (this._world.previousSession.get(registry.addonId)?.disabled) continue;
+            scope.add(kairoId);
+        }
         const plan = this.resolutionService.resolve(this._world, scope);
         this._activationOrder = plan.orderedKairoIds;
         console.log(`[Kairo] Resolution Phase complete: ${plan.orderedKairoIds.length} addon(s) scheduled for activation`);
@@ -186,15 +192,20 @@ export class ActivationController {
                 message: "Manually deactivated",
             });
             console.log(`[Kairo UI] Disabled: ${label}`);
+            const registry = world.registries.get(kairoId);
+            if (registry) {
+                world.previousSession.set(registry.addonId, {
+                    version: registry.version,
+                    origin: "explicit",
+                    disabled: true,
+                });
+            }
         }
     }
 
     async executeEnable(kairoId: KairoId, origin: "latest" | "explicit"): Promise<void> {
         const world = this.world;
-        const { plan } = this.previewEnable(kairoId);
-        await this.activationService.activate(world, plan);
 
-        // Update previousSession
         const registry = world.registries.get(kairoId);
         if (registry) {
             world.previousSession.set(registry.addonId, {
@@ -202,6 +213,9 @@ export class ActivationController {
                 origin,
             });
         }
+
+        const { plan } = this.previewEnable(kairoId);
+        await this.activationService.activate(world, plan);
     }
 
     async executeVersionSwitch(oldKairoId: KairoId, newKairoId: KairoId): Promise<void> {
@@ -232,6 +246,15 @@ export class ActivationController {
                 code: InactiveReasonCode.ADDON_ID_CONFLICT,
                 message: "Superseded by version switch",
                 related: [newKairoId],
+            });
+        }
+
+        // Update session before previewEnable so ConflictResolver picks the new version
+        const newRegistry = world.registries.get(newKairoId);
+        if (newRegistry) {
+            world.previousSession.set(newRegistry.addonId, {
+                version: newRegistry.version,
+                origin: "explicit",
             });
         }
 

--- a/src/kairo/activation/types/world.ts
+++ b/src/kairo/activation/types/world.ts
@@ -5,6 +5,7 @@ import type { AddonId, AddonRuntimeState, KairoId } from "./state";
 export type PreviousSessionEntry = {
     readonly version: SemVer;
     readonly origin: "explicit" | "latest";
+    readonly disabled?: boolean;
 };
 
 export type PreviousSessionStore = Map<AddonId, PreviousSessionEntry>;

--- a/src/kairo/ui/constants/TranslateKeys.ts
+++ b/src/kairo/ui/constants/TranslateKeys.ts
@@ -13,7 +13,7 @@ export const T = {
         disable:      "kairo.form.detail.disable",
         latest:       "kairo.form.detail.latest",
         submitButton: "kairo.form.detail.submit",
-        kairoId:      "kairo.form.detail.kairoId",
+        developer:    "kairo.form.detail.developer",
         addonId:      "kairo.form.detail.addonId",
         state:        "kairo.form.detail.state",
         reasons:      "kairo.form.detail.reasons",

--- a/src/kairo/ui/screens/AddonDetailScreen.ts
+++ b/src/kairo/ui/screens/AddonDetailScreen.ts
@@ -51,7 +51,14 @@ export class AddonDetailScreen {
             return SemVerUtils.format(world.registries.get(e.kairoId)!.version);
         });
 
-        const defaultIndex = entries.findIndex(e => e.kind === "latest");
+        const session = world.previousSession.get(addonId);
+        const defaultIndex = (() => {
+            if (session?.origin === "explicit" && activeId) {
+                const idx = entries.findIndex(e => e.kind === "version" && e.kairoId === activeId);
+                if (idx >= 0) return idx;
+            }
+            return entries.findIndex(e => e.kind === "latest");
+        })();
 
         // State of the addonId group
         const groupState = activeId
@@ -61,22 +68,33 @@ export class AddonDetailScreen {
         const versionText = activeId
             ? SemVerUtils.format(world.registries.get(activeId)!.version)
             : "-";
+        const isLatestMode = !!activeId && session?.origin !== "explicit";
 
         // Build form — label/divider も formValues に null で入るので dropdown 位置を追跡
         let fi = 0; // formIndex
         const form = new ModalFormData().title({ translate: displayRegistry.name });
 
-        form.label(displayRegistry.name);                                  fi++;
+        form.label(`${displayRegistry.name}\n§7${displayRegistry.description}§r`); fi++;
         form.divider();                                                    fi++;
-        form.label(`§7id: §r${addonId}`);                                 fi++;
         form.label({
             rawtext: [
-                { text: "§7state: §r" },
+                { text: `§7id: §r${addonId}\n§7version: §r${versionText}` },
+                ...(isLatestMode
+                    ? [{ text: " §7(" }, { translate: T.detail.latest }, { text: ")§r" }]
+                    : []
+                ),
+                { text: "\n§7state: §r" },
                 { text: STATE_COLOR[groupState] },
                 { translate: STATE_KEY[groupState] },
+                ...(displayRegistry.tags.length > 0 ? [
+                    { text: "\n§7tags: §r" },
+                    ...displayRegistry.tags.flatMap((tag, i) => [
+                        ...(i > 0 ? [{ text: ", " }] : []),
+                        { translate: `kairo.tags.${tag}` },
+                    ]),
+                ] : []),
             ],
         });                                                                fi++;
-        form.label(`§7version: §r${versionText}`);                        fi++;
         form.divider();                                                    fi++;
 
         const dropdownFormIndex = fi;
@@ -84,9 +102,18 @@ export class AddonDetailScreen {
 
         form.divider();
         const depsText = this.buildDepsText(displayRegistry);
-        form.label(depsText ?? { translate: T.detail.deps.none });
-        form.divider();
-        form.label(`§7kairoId: §r${displayId}`);
+        const dependentsText = this.buildDependentsText(addonId, world);
+        const metadataText = this.buildMetadataText(displayRegistry);
+        form.label({
+            rawtext: [
+                { text: "§7" },
+                { translate: T.detail.developer },
+                { text: `§r\n  §7id:§r ${displayId}` },
+                ...(metadataText ? [{ text: "\n" + metadataText }] : []),
+                ...(depsText ? [{ text: "\n\n" + depsText }] : []),
+                ...(dependentsText ? [{ text: "\n\n" + dependentsText }] : []),
+            ],
+        });
         form.submitButton({ translate: T.detail.submitButton });
 
         const response = await form.show(player);
@@ -128,17 +155,49 @@ export class AddonDetailScreen {
 
         const deps = Object.entries(registry.dependencies);
         if (deps.length > 0) {
-            lines.push("§7dependencies:§r");
-            for (const [id, ver] of deps) lines.push(`  §7${id}§r: ${ver}`);
+            lines.push("  §7dependencies:§r");
+            for (const [id, ver] of deps) lines.push(`    §7${id}§r: ${ver}`);
         }
 
         const opts = Object.entries(registry.optionalDependencies);
         if (opts.length > 0) {
             if (lines.length > 0) lines.push("");
-            lines.push("§7optional:§r");
-            for (const [id, ver] of opts) lines.push(`  §7${id}§r: ${ver}`);
+            lines.push("  §7optional:§r");
+            for (const [id, ver] of opts) lines.push(`    §7${id}§r: ${ver}`);
         }
 
         return lines.length > 0 ? lines.join("\n") : null;
+    }
+
+    private buildMetadataText(registry: KairoRegistry): string | null {
+        const lines: string[] = [];
+        const { authors, url, license } = registry.metadata;
+        if (authors.length > 0) lines.push(`  §7authors:§r ${authors.join(", ")}`);
+        if (url)     lines.push(`  §7url:§r ${url}`);
+        if (license) lines.push(`  §7license:§r ${license}`);
+        return lines.length > 0 ? lines.join("\n") : null;
+    }
+
+    private buildDependentsText(addonId: string, world: KairoWorldState): string | null {
+        const lines: string[] = [];
+        const seen = new Set<string>();
+
+        for (const [kairoId, rt] of world.runtimes) {
+            if (rt.state !== AddonState.ACTIVE) continue;
+            const registry = world.registries.get(kairoId);
+            if (!registry || registry.addonId === addonId) continue;
+            if (seen.has(registry.addonId)) continue;
+
+            const isRequired = addonId in registry.dependencies;
+            const isOptional = addonId in registry.optionalDependencies;
+            if (!isRequired && !isOptional) continue;
+
+            seen.add(registry.addonId);
+            const suffix = isOptional && !isRequired ? " §7(optional)§r" : "";
+            lines.push(`    §7${registry.name}§r${suffix}`);
+        }
+
+        if (lines.length === 0) return null;
+        return "  §7dependents:§r\n" + lines.join("\n");
     }
 }


### PR DESCRIPTION
## Summary
- UI 改善: description / tags / metadata / dependents を追加、レイアウト整理
- バグ修正: バージョン切り替え時に previousSession の更新順序が誤っていた問題を修正

## Changes
### UI
- 名前の下に description を表示
- id / version / state を1ラベルに統合
- version に Latest モード表示を追加
- tags を info セクションに表示（i18n 対応）
- dependencies を Developer セクションに移動
- dependents（依存元 ACTIVE アドオン）を Developer セクションに追加
- metadata（authors / url / license）を Developer セクションに追加

### Bug Fix
- executeVersionSwitch / executeEnable で previousSession を
  previewEnable の前に更新するよう修正（ConflictResolver が
  古いセッションを参照して旧バージョンを再起動する問題を解消）