### PR TITLE
feat(ui): manual enable with dependency confirmation + enriched addon detail screen

### DIFF
--- a/RP/texts/en_US.lang
+++ b/RP/texts/en_US.lang
@@ -52,6 +52,7 @@ kairo.form.addon.unresolved=Unresolved
 
 kairo.form.detail.version.label=Version
 kairo.form.detail.disable=Disable
+kairo.form.detail.inactive=Inactive
 kairo.form.detail.latest=Latest Version
 kairo.form.detail.submit=Apply
 kairo.form.detail.deps.none=No dependencies

--- a/RP/texts/ja_JP.lang
+++ b/RP/texts/ja_JP.lang
@@ -52,6 +52,7 @@ kairo.form.addon.unresolved=未解決
 
 kairo.form.detail.version.label=バージョン
 kairo.form.detail.disable=無効にする
+kairo.form.detail.inactive=現在無効
 kairo.form.detail.latest=最新バージョン
 kairo.form.detail.submit=適用
 kairo.form.detail.deps.none=依存関係なし

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,6 @@
-import { AddonActivateAfterEvent, router } from "@kairo-js/router";
+import { router } from "@kairo-js/router";
 import { kairo } from "./kairo/Kairo";
 import { properties } from "./properties";
 
 kairo.init();
 kairo.router.init(properties);
-
-router.afterEvents.addonActivate.subscribe((ev: AddonActivateAfterEvent) => {
-    console.log("kairo が起動した！！！");
-});

--- a/src/kairo/Kairo.ts
+++ b/src/kairo/Kairo.ts
@@ -40,7 +40,6 @@ class Kairo {
     }
 
     private readonly onInitComplete = () => {
-        console.log("Kairo initialization complete.");
         (async (): Promise<void> => {
             if (!this.runtime) {
                 throw new KairoError(KairoErrorReason.RuntimeNotInitialized);

--- a/src/kairo/activation/ActivationController.ts
+++ b/src/kairo/activation/ActivationController.ts
@@ -67,7 +67,6 @@ export class ActivationController {
     startupResolve(): ActivationPlan {
         this._world = this.buildWorldState();
         this._world.cachedDeclaredReverseGraph = this.buildReverseGraph(this._world);
-        console.log(`[Kairo] Resolution Phase: ${this._world.runtimes.size} addon(s) registered`);
         const scope = new Set<KairoId>();
         for (const kairoId of this._world.runtimes.keys()) {
             const registry = this._world.registries.get(kairoId);
@@ -77,14 +76,11 @@ export class ActivationController {
         }
         const plan = this.resolutionService.resolve(this._world, scope);
         this._activationOrder = plan.orderedKairoIds;
-        console.log(`[Kairo] Resolution Phase complete: ${plan.orderedKairoIds.length} addon(s) scheduled for activation`);
         return plan;
     }
 
     async startupActivate(plan: ActivationPlan): Promise<void> {
-        console.log(`[Kairo] Activation Phase: starting`);
         await this.activationService.activate(this.world, plan);
-        console.log(`[Kairo] Activation Phase complete`);
     }
 
     // ── Preview methods ──────────────────────────────────────────
@@ -115,7 +111,7 @@ export class ActivationController {
     previewEnable(kairoId: KairoId): EnablePreview {
         const world = this.world;
         const scope = this.buildManualActivateScope(kairoId);
-        const plan = this.resolutionService.resolve(world, scope);
+        const plan = this.resolutionService.resolve(world, scope, true);
 
         const toActivate = plan.orderedKairoIds.filter(id => {
             return world.runtimes.get(id)?.state === AddonState.INACTIVE;
@@ -166,7 +162,6 @@ export class ActivationController {
         const world = this.world;
         const registry = world.registries.get(kairoId);
         const label = registry ? `${registry.addonId}@${registry.version.major}.${registry.version.minor}.${registry.version.patch}` : kairoId;
-        console.log(`[Kairo UI] Disabling: ${label}`);
 
         const { cascadeVictims } = this.previewDisable(kairoId);
 
@@ -184,14 +179,12 @@ export class ActivationController {
         }
 
         const success = await this.deactivationExecutor.deactivate(kairoId);
-        console.log(`[Kairo UI] Deactivate result: ${success ? "success" : "failed"}`);
         const rt = world.runtimes.get(kairoId);
         if (rt && success) {
             setInactive(rt, {
                 code: InactiveReasonCode.MANUALLY_DEACTIVATED,
                 message: "Manually deactivated",
             });
-            console.log(`[Kairo UI] Disabled: ${label}`);
             const registry = world.registries.get(kairoId);
             if (registry) {
                 world.previousSession.set(registry.addonId, {

--- a/src/kairo/activation/ActivationService.ts
+++ b/src/kairo/activation/ActivationService.ts
@@ -21,19 +21,10 @@ export class ActivationService {
         };
 
         for (const kairoId of plan.orderedKairoIds) {
-            if (context.blockedKairoIds.has(kairoId)) {
-                const registry = world.registries.get(kairoId);
-                const label = registry ? `${registry.addonId}@${registry.version.major}.${registry.version.minor}.${registry.version.patch}` : kairoId;
-                console.warn(`[Kairo] SKIPPED (dependency failed): ${label}`);
-                continue;
-            }
+            if (context.blockedKairoIds.has(kairoId)) continue;
 
             // Optional activation may have already activated this addon
             if (world.runtimes.get(kairoId)?.state === AddonState.ACTIVE) continue;
-
-            const registry = world.registries.get(kairoId);
-            const label = registry ? `${registry.addonId}@${registry.version.major}.${registry.version.minor}.${registry.version.patch}` : kairoId;
-            console.log(`[Kairo] Activating: ${label}`);
 
             const outcome = await this.executor.activate(kairoId);
 
@@ -44,14 +35,6 @@ export class ActivationService {
                 plan.resolvedReverseDependencyGraph,
                 context.blockedKairoIds,
             );
-
-            if (outcome.type === "SUCCESS") {
-                console.log(`[Kairo] Activated: ${label}`);
-            } else if (outcome.type === "FAILED") {
-                console.error(`[Kairo] FAILED: ${label} — ${outcome.reason ?? "unknown"}`);
-            } else {
-                console.error(`[Kairo] TIMEOUT: ${label}`);
-            }
 
             if (outcome.type !== "SUCCESS") continue;
 

--- a/src/kairo/activation/OptionalActivator.ts
+++ b/src/kairo/activation/OptionalActivator.ts
@@ -69,20 +69,8 @@ export class OptionalActivator {
             for (const id of plan.orderedKairoIds) {
                 if (blockedKairoIds.has(id)) continue;
 
-                const r = world.registries.get(id);
-                const label = r ? `${r.addonId}@${r.version.major}.${r.version.minor}.${r.version.patch}` : id;
-                console.log(`[Kairo] Activating (optional): ${label}`);
-
                 const outcome = await this.executor.activate(id);
                 outcomes.set(id, outcome);
-
-                if (outcome.type === "SUCCESS") {
-                    console.log(`[Kairo] Activated (optional): ${label}`);
-                } else if (outcome.type === "FAILED") {
-                    console.warn(`[Kairo] FAILED (optional): ${label} — ${outcome.reason ?? "unknown"}`);
-                } else {
-                    console.warn(`[Kairo] TIMEOUT (optional): ${label}`);
-                }
 
                 if (outcome.type !== "SUCCESS") {
                     const deps = plan.resolvedReverseDependencyGraph.get(id);

--- a/src/kairo/activation/resolution/ActivationPlanner.ts
+++ b/src/kairo/activation/resolution/ActivationPlanner.ts
@@ -9,6 +9,7 @@ export class ActivationPlanner {
         dependencyGraph: ReadonlyMap<KairoId, ReadonlySet<KairoId>>,
         resolvedReverseDependencyGraph: ReadonlyMap<KairoId, ReadonlySet<KairoId>>,
         previousSession: PreviousSessionStore,
+        ignoreManualBlock = false,
     ): ActivationPlan {
         const activeIds = new Set<KairoId>();
         for (const [id, rt] of runtimes) {
@@ -39,7 +40,7 @@ export class ActivationPlanner {
         };
 
         const initialQueue = prioritize(
-            [...scope.keys()].filter(id => canActivate(id, availableDependencies, scope, dependencyGraph)),
+            [...scope.keys()].filter(id => canActivate(id, availableDependencies, scope, dependencyGraph, ignoreManualBlock)),
         );
 
         const queue: KairoId[] = initialQueue;
@@ -47,7 +48,7 @@ export class ActivationPlanner {
 
         while (queue.length > 0) {
             const id = queue.shift()!;
-            if (!canActivate(id, availableDependencies, scope, dependencyGraph)) continue;
+            if (!canActivate(id, availableDependencies, scope, dependencyGraph, ignoreManualBlock)) continue;
 
             orderedKairoIds.push(id);
             availableDependencies.add(id);
@@ -61,7 +62,7 @@ export class ActivationPlanner {
                 const updated = Math.max(0, current - 1);
                 inDegree.set(depId, updated);
 
-                if (updated === 0 && canActivate(depId, availableDependencies, scope, dependencyGraph)) {
+                if (updated === 0 && canActivate(depId, availableDependencies, scope, dependencyGraph, ignoreManualBlock)) {
                     newlyReady.push(depId);
                 }
             }
@@ -92,6 +93,7 @@ function canActivate(
     availableDependencies: ReadonlySet<KairoId>,
     scope: ReadonlyMap<KairoId, AddonRuntimeState>,
     dependencyGraph: ReadonlyMap<KairoId, ReadonlySet<KairoId>>,
+    ignoreManualBlock = false,
 ): boolean {
     if (!scope.has(kairoId)) return false;
 
@@ -101,7 +103,7 @@ function canActivate(
     if (runtime.inactiveReasons.has(InactiveReasonCode.ACTIVATION_TIMEOUT)) return false;
     if (runtime.inactiveReasons.has(InactiveReasonCode.ADDON_ID_CONFLICT)) return false;
     if (runtime.inactiveReasons.has(InactiveReasonCode.PRERELEASE_ONLY)) return false;
-    if (runtime.inactiveReasons.has(InactiveReasonCode.MANUALLY_DEACTIVATED)) return false;
+    if (!ignoreManualBlock && runtime.inactiveReasons.has(InactiveReasonCode.MANUALLY_DEACTIVATED)) return false;
 
     for (const depId of dependencyGraph.get(kairoId) ?? []) {
         if (!availableDependencies.has(depId)) return false;

--- a/src/kairo/activation/resolution/ResolutionService.ts
+++ b/src/kairo/activation/resolution/ResolutionService.ts
@@ -19,6 +19,7 @@ export class ResolutionService {
     resolve(
         world: KairoWorldState,
         scope: ReadonlySet<KairoId>,
+        ignoreManualBlock = false,
     ): ActivationPlan {
         // Step 0: reset resolution-generated reasons
         resetReasons(scope, world.runtimes);
@@ -81,24 +82,8 @@ export class ResolutionService {
             ctx.dependencyGraph,
             ctx.resolvedReverseDependencyGraph,
             world.previousSession,
+            ignoreManualBlock,
         );
-
-        for (const [kairoId, runtime] of world.runtimes) {
-            if (!scope.has(kairoId)) continue;
-            const registry = world.registries.get(kairoId);
-            const label = registry ? `${registry.addonId}@${registry.version.major}.${registry.version.minor}.${registry.version.patch}` : kairoId;
-            if (runtime.state === AddonState.UNRESOLVED) {
-                const reasons = [...runtime.unresolvedReasons.keys()].join(", ");
-                console.warn(`[Kairo] UNRESOLVED: ${label} (${reasons})`);
-            } else if (runtime.inactiveReasons.size > 0) {
-                const reasons = [...runtime.inactiveReasons.keys()].join(", ");
-                console.warn(`[Kairo] INACTIVE: ${label} (${reasons})`);
-            }
-        }
-
-        if (cyclicNodes.size > 0) {
-            console.warn(`[Kairo] Circular dependencies detected: ${cyclicNodes.size} addon(s) affected`);
-        }
 
         return plan;
     }

--- a/src/kairo/ui/KairoUI.ts
+++ b/src/kairo/ui/KairoUI.ts
@@ -34,7 +34,6 @@ export class KairoUI {
         // kairo 自身は無効化不可（バージョン切替のみ）
         const disableAllowed = selectedAddonId !== "kairo";
         const result = await this.addonDetail.show(player, selectedAddonId, world, disableAllowed);
-        console.log(`[Kairo UI] Detail result: ${JSON.stringify(result)}`);
         if (!result) return;
 
         if (result.type === "disable") {

--- a/src/kairo/ui/constants/TranslateKeys.ts
+++ b/src/kairo/ui/constants/TranslateKeys.ts
@@ -11,6 +11,7 @@ export const T = {
     detail: {
         versionLabel: "kairo.form.detail.version.label",
         disable:      "kairo.form.detail.disable",
+        inactive:     "kairo.form.detail.inactive",
         latest:       "kairo.form.detail.latest",
         submitButton: "kairo.form.detail.submit",
         developer:    "kairo.form.detail.developer",

--- a/src/kairo/ui/screens/AddonDetailScreen.ts
+++ b/src/kairo/ui/screens/AddonDetailScreen.ts
@@ -12,6 +12,7 @@ export type DetailResult =
     | null;
 
 type DropdownEntry =
+    | { readonly kind: "inactive" }
     | { readonly kind: "disable" }
     | { readonly kind: "latest" }
     | { readonly kind: "version"; readonly kairoId: KairoId };
@@ -38,32 +39,36 @@ export class AddonDetailScreen {
         const displayId = activeId ?? this.resolveLatest(addonId, world, selectableIds) ?? kairoIds[0]!;
         const displayRegistry = world.registries.get(displayId)!;
 
+        // State of the addonId group
+        const groupState = activeId
+            ? AddonState.ACTIVE
+            : selectableIds.length > 0 ? AddonState.INACTIVE : AddonState.UNRESOLVED;
+
         // Dropdown entries
+        const isActive = groupState === AddonState.ACTIVE;
         const entries: DropdownEntry[] = [
-            ...(disableAllowed ? [{ kind: "disable" as const }] : []),
+            ...(!isActive ? [{ kind: "inactive" as const }] : []),
+            ...(isActive && disableAllowed ? [{ kind: "disable" as const }] : []),
             { kind: "latest" },
             ...selectableIds.map(id => ({ kind: "version" as const, kairoId: id })),
         ];
 
         const labels = entries.map(e => {
-            if (e.kind === "disable") return { translate: T.detail.disable };
-            if (e.kind === "latest")  return { translate: T.detail.latest };
+            if (e.kind === "inactive") return { translate: T.detail.inactive };
+            if (e.kind === "disable")  return { translate: T.detail.disable };
+            if (e.kind === "latest")   return { translate: T.detail.latest };
             return SemVerUtils.format(world.registries.get(e.kairoId)!.version);
         });
 
         const session = world.previousSession.get(addonId);
         const defaultIndex = (() => {
+            if (!isActive) return entries.findIndex(e => e.kind === "inactive");
             if (session?.origin === "explicit" && activeId) {
                 const idx = entries.findIndex(e => e.kind === "version" && e.kairoId === activeId);
                 if (idx >= 0) return idx;
             }
             return entries.findIndex(e => e.kind === "latest");
         })();
-
-        // State of the addonId group
-        const groupState = activeId
-            ? AddonState.ACTIVE
-            : selectableIds.length > 0 ? AddonState.INACTIVE : AddonState.UNRESOLVED;
 
         const versionText = activeId
             ? SemVerUtils.format(world.registries.get(activeId)!.version)
@@ -125,6 +130,7 @@ export class AddonDetailScreen {
         const selected = entries[selectedIndex];
         if (!selected) return null;
 
+        if (selected.kind === "inactive") return null;
         if (selected.kind === "disable") return { type: "disable" };
         if (selected.kind === "latest") {
             const latestId = this.resolveLatest(addonId, world, selectableIds);


### PR DESCRIPTION
## Summary

- **手動有効化フローの修正**: MANUALLY_DEACTIVATED なアドオンを依存に持つアドオンを有効化しようとすると、確認ダイアログが表示されずに何も起きないバグを修正
- **アドオン詳細画面の拡充**: 説明・バージョン・状態・タグ・依存関係・被依存情報・開発者情報を表示するよう拡張
- **デバッグログの全削除**: プロダクションコードから console.log/warn/error を全て除去

## Changes

### Bug fix: manual enable with MANUALLY_DEACTIVATED dependency

`ActivationPlanner.canActivate` は通常、`MANUALLY_DEACTIVATED` なアドオンをブロックする（起動時の自動復帰防止）。しかし手動有効化（`previewEnable`）コンテキストでは、ユーザーが明示的に有効化を要求しているため、依存チェーン上の MANUALLY_DEACTIVATED アドオンもプランに含めるべきである。

`ignoreManualBlock` フラグを `canActivate` → `buildPlan` → `ResolutionService.resolve` に追加し、`previewEnable` からは `true` を渡すことで解決した。起動時 Resolution と `OptionalActivator` は従来通り `false`（デフォルト）のまま。

**再現手順**: Chain Base を無効化 → Chain Top から有効化 → 確認ダイアログが出ず何も起きない
**修正後**: Chain Base・Chain Mid も有効化する確認ダイアログが表示され、全3つが起動する

### Enriched AddonDetailScreen

詳細画面に以下を追加:
- アドオンの説明文・現在バージョン・状態（カラー表示）・タグ
- `dependents`: 現在そのアドオンに依存している ACTIVE なアドオン一覧
- `dependencies` / `optional`: 依存先アドオンと要求バージョン
- `developer` セクション: kairoId・authors・url・license

## Test plan

- [ ] Solo: enable / disable がダイアログなしで動作する
- [ ] Multi: バージョン切り替えが正しく動作する（Latest = v3.0.0）
- [ ] Chain: Base 無効化 → Top から有効化で確認ダイアログ表示 → 全3つ起動
- [ ] Chain: Base 無効化 → Mid から有効化で Base も一緒に確認ダイアログ表示
- [ ] Lib/App: v2→v1切り替えで App も有効化、v1→v2切り替えで App の無効化確認ダイアログ
- [ ] Stable/Consumer: v1.0.0→v1.1.0切り替えで Consumer はそのまま ACTIVE（ダイアログなし）
- [ ] Optional: Consumer 有効化 → Provider が自動起動、Provider 詳細に Consumer が表示される