### PR TITLE
feat: activation system refactor + addon management UI

### DIFF
--- a/RP/texts/en_US.lang
+++ b/RP/texts/en_US.lang
@@ -67,4 +67,5 @@ kairo.form.confirm.yes=Yes
 kairo.form.confirm.no=No
 kairo.form.confirm.disable.cascade=Disabling this addon will also disable the following addons:
 kairo.form.confirm.enable.deps=The following addons are required and will also be enabled:
+kairo.form.confirm.enable.version.switch=To enable this addon, the following dependency versions will be switched:
 kairo.form.confirm.version.switch.cascade=Switching to this version will disable the following incompatible addons:

--- a/RP/texts/ja_JP.lang
+++ b/RP/texts/ja_JP.lang
@@ -67,4 +67,5 @@ kairo.form.confirm.yes=はい
 kairo.form.confirm.no=いいえ
 kairo.form.confirm.disable.cascade=このアドオンを無効化すると、以下のアドオンも無効化されます：
 kairo.form.confirm.enable.deps=以下の前提アドオンも一緒に有効化されます：
+kairo.form.confirm.enable.version.switch=このアドオンを有効化するには、以下の依存ライブラリのバージョンを変更します：
 kairo.form.confirm.version.switch.cascade=このバージョンに切り替えると、互換性のない以下のアドオンが無効化されます：

--- a/src/kairo/activation/ActivationController.ts
+++ b/src/kairo/activation/ActivationController.ts
@@ -24,9 +24,15 @@ export type DisablePreview = {
     readonly cascadeVictims: readonly KairoId[];
 };
 
+export type ImplicitVersionSwitch = {
+    readonly from: KairoId;
+    readonly to: KairoId;
+};
+
 export type EnablePreview = {
     readonly plan: ActivationPlan;
     readonly toActivate: readonly KairoId[];
+    readonly implicitVersionSwitches: readonly ImplicitVersionSwitch[];
 };
 
 export type VersionSwitchPreview = {
@@ -111,13 +117,30 @@ export class ActivationController {
     previewEnable(kairoId: KairoId): EnablePreview {
         const world = this.world;
         const scope = this.buildManualActivateScope(kairoId);
+
+        // Snapshot active state before resolve to detect implicit version switches
+        const preActiveIds = new Set<KairoId>();
+        for (const [id, rt] of world.runtimes) {
+            if (rt.state === AddonState.ACTIVE) preActiveIds.add(id);
+        }
+
         const plan = this.resolutionService.resolve(world, scope, true);
 
         const toActivate = plan.orderedKairoIds.filter(id => {
             return world.runtimes.get(id)?.state === AddonState.INACTIVE;
         });
 
-        return { plan, toActivate };
+        // Detect implicit version switches: plan members that displaced a previously-ACTIVE version
+        const implicitVersionSwitches: ImplicitVersionSwitch[] = [];
+        for (const planId of plan.orderedKairoIds) {
+            const planReg = world.registries.get(planId);
+            if (!planReg) continue;
+            const displaced = [...(world.addonIdIndex.get(planReg.addonId) ?? [])]
+                .find(id => id !== planId && preActiveIds.has(id));
+            if (displaced) implicitVersionSwitches.push({ from: displaced, to: planId });
+        }
+
+        return { plan, toActivate, implicitVersionSwitches };
     }
 
     previewVersionSwitch(newKairoId: KairoId): VersionSwitchPreview {
@@ -197,17 +220,40 @@ export class ActivationController {
     }
 
     async executeEnable(kairoId: KairoId, origin: "latest" | "explicit"): Promise<void> {
+        const { plan, implicitVersionSwitches } = this.previewEnable(kairoId);
+        await this.executeEnableWithPlan(kairoId, origin, plan, implicitVersionSwitches);
+    }
+
+    async executeEnableWithPlan(
+        kairoId: KairoId,
+        origin: "latest" | "explicit",
+        plan: ActivationPlan,
+        implicitVersionSwitches: readonly ImplicitVersionSwitch[],
+    ): Promise<void> {
         const world = this.world;
 
         const registry = world.registries.get(kairoId);
         if (registry) {
-            world.previousSession.set(registry.addonId, {
-                version: registry.version,
-                origin,
-            });
+            world.previousSession.set(registry.addonId, { version: registry.version, origin });
         }
 
-        const { plan } = this.previewEnable(kairoId);
+        // Deactivate displaced versions before activating the plan
+        for (const { from: oldId } of implicitVersionSwitches) {
+            const { cascadeVictims } = this.previewDisable(oldId);
+            for (const victimId of cascadeVictims) {
+                const victimRt = world.runtimes.get(victimId);
+                if (!victimRt || victimRt.state !== AddonState.ACTIVE) continue;
+                await this.deactivationExecutor.deactivate(victimId);
+                setInactive(victimRt, {
+                    code: InactiveReasonCode.CASCADE_DEACTIVATED,
+                    message: `Dependency ${oldId} was switched`,
+                    related: [oldId],
+                });
+            }
+            // Still running in Minecraft despite in-memory INACTIVE state set by ConflictResolver
+            await this.deactivationExecutor.deactivate(oldId);
+        }
+
         await this.activationService.activate(world, plan);
     }
 

--- a/src/kairo/activation/resolution/ConflictResolver.ts
+++ b/src/kairo/activation/resolution/ConflictResolver.ts
@@ -36,6 +36,15 @@ export class ConflictResolver {
     private pickWinner(group: Set<KairoId>, ctx: ResolutionContext): KairoId {
         const ids = [...group];
 
+        // Priority 0 (manual enable only): prefer version that is required by another addon in scope
+        if (ctx.ignoreManualBlock) {
+            for (const id of ids) {
+                for (const deps of ctx.dependencyGraph.values()) {
+                    if (deps.has(id)) return id;
+                }
+            }
+        }
+
         // Priority 1: previous session explicit version
         for (const id of ids) {
             const registry = ctx.registries.get(id);

--- a/src/kairo/activation/resolution/ResolutionService.ts
+++ b/src/kairo/activation/resolution/ResolutionService.ts
@@ -50,6 +50,7 @@ export class ResolutionService {
             runtimes: world.runtimes,
             addonIdIndex: world.addonIdIndex,
             previousSession: world.previousSession,
+            ignoreManualBlock,
             declaredDependencyGraph,
             dependencyGraph: new Map(),
             resolvedReverseDependencyGraph: new Map(),

--- a/src/kairo/activation/types/context.ts
+++ b/src/kairo/activation/types/context.ts
@@ -9,6 +9,7 @@ export type ResolutionContext = {
     readonly runtimes: ReadonlyMap<KairoId, AddonRuntimeState>;
     readonly addonIdIndex: ReadonlyMap<AddonId, ReadonlySet<KairoId>>;
     readonly previousSession: PreviousSessionStore;
+    readonly ignoreManualBlock: boolean;
 
     declaredDependencyGraph: Map<KairoId, Set<AddonDependencySpec>>;
     dependencyGraph: Map<KairoId, Set<KairoId>>;

--- a/src/kairo/ui/KairoUI.ts
+++ b/src/kairo/ui/KairoUI.ts
@@ -97,10 +97,21 @@ export class KairoUI {
         }
 
         // Fresh enable
-        const { toActivate } = this.controller.previewEnable(newKairoId);
+        const { plan, toActivate, implicitVersionSwitches } = this.controller.previewEnable(newKairoId);
         const depsToActivate = toActivate.filter(id => id !== newKairoId);
 
-        if (depsToActivate.length > 0) {
+        if (implicitVersionSwitches.length > 0) {
+            const names = implicitVersionSwitches.map(({ from, to }) => {
+                const fromReg = world.registries.get(from);
+                const toReg = world.registries.get(to);
+                const name = toReg?.name ?? to;
+                const fromVer = fromReg ? SemVerUtils.format(fromReg.version) : from;
+                const toVer = toReg ? SemVerUtils.format(toReg.version) : to;
+                return `${name}  ${fromVer} > ${toVer}`;
+            });
+            const confirmed = await this.confirm.show(player, T.confirm.enableVersionSwitch, names);
+            if (!confirmed) return;
+        } else if (depsToActivate.length > 0) {
             const names = depsToActivate.map(id => {
                 const reg = world.registries.get(id);
                 return reg ? reg.name : id;
@@ -109,6 +120,6 @@ export class KairoUI {
             if (!confirmed) return;
         }
 
-        await this.controller.executeEnable(newKairoId, origin);
+        await this.controller.executeEnableWithPlan(newKairoId, origin, plan, implicitVersionSwitches);
     }
 }

--- a/src/kairo/ui/constants/TranslateKeys.ts
+++ b/src/kairo/ui/constants/TranslateKeys.ts
@@ -31,8 +31,9 @@ export const T = {
         title:              "kairo.form.confirm.title",
         yes:                "kairo.form.confirm.yes",
         no:                 "kairo.form.confirm.no",
-        disableCascade:     "kairo.form.confirm.disable.cascade",
-        enableDeps:         "kairo.form.confirm.enable.deps",
+        disableCascade:       "kairo.form.confirm.disable.cascade",
+        enableDeps:           "kairo.form.confirm.enable.deps",
+        enableVersionSwitch:  "kairo.form.confirm.enable.version.switch",
         versionSwitchCascade: "kairo.form.confirm.version.switch.cascade",
     },
 } as const;


### PR DESCRIPTION
## Summary

- Activation システムを Resolution Phase / Activation Phase に分離し、依存解決ロジックを完全に再実装
- アドオン管理 UI（一覧・詳細・確認ダイアログ）を新規実装
- 手動有効化フロー（依存関係の同時有効化、暗黙的バージョン切り替え）を実装

## Changes

### Activation system refactor

旧実装（`StartupActivationPlanner` / `AddonDependencyResolver` など）を廃止し、以下のサービス群に再設計:

| クラス | 役割 |
|---|---|
| `ResolutionService` | Resolution Phase の統括 (Step 0–7) |
| `GraphBuilder` | 宣言型依存グラフの構築 |
| `CycleDetector` | 循環依存検出 |
| `DependencyResolver` | 依存 spec → KairoId への解決 |
| `ConflictResolver` | 同一 addonId 競合の解決 (priority-based) |
| `ActivationPlanner` | Kahn's algorithm によるトポロジカルソート |
| `ReasonResetService` | Resolution 開始時の reason リセット |
| `ActivationService` | Activation Phase の実行 |
| `OptionalActivator` | optional 依存のサブグラフ解決・起動 |
| `DeactivationExecutor` | 停止リクエストの送信 |

### Manual enable flow

- 手動有効化時は `ignoreManualBlock=true` で Resolution を実行し、`MANUALLY_DEACTIVATED` な依存もプランに含める
- `previewEnable` が `toActivate` に加え `implicitVersionSwitches` を返すよう拡張
- 確認ダイアログを2種類に分岐:
  - **依存アドオンの同時有効化**: "以下の前提アドオンも一緒に有効化されます"
  - **暗黙的バージョン切り替え**: "以下の依存ライブラリのバージョンが変更されます"

### Implicit version switch on enable

- 有効化したいアドオンの依存バージョンが現在 ACTIVE なバージョンと競合する場合（例: App が Lib ^1.0.0 を要求するが Lib 2.0.0 が ACTIVE）を検出
- `ConflictResolver` に Priority 0 を追加（`ignoreManualBlock=true` 時のみ）: 依存グラフで参照されているバージョンを優先
- `executeEnableWithPlan` が旧バージョンを deactivate してから新バージョンとアドオンを activate

### Addon management UI

- `AddonListScreen`: アドオン一覧（状態カラー表示、起動順ソート）
- `AddonDetailScreen`: バージョン選択ドロップダウン、説明・状態・タグ・依存関係・被依存情報・開発者情報
- `AddonUnresolvedScreen`: UNRESOLVED 理由の表示
- `ConfirmScreen`: 汎用確認ダイアログ（Yes/No）

## Test plan

- [ ] 起動時: latest バージョンが正しく選ばれる（ui-lib → v2.0.0、ui-multi → v3.0.0）
- [ ] Solo: enable / disable がダイアログなしで動作する
- [ ] Chain: Base 無効化 → Top から有効化で確認ダイアログ → 全3つ起動
- [ ] Lib/App: App 有効化時に Lib v2→v1 の切り替えダイアログが出る → 切り替わる
- [ ] Lib/App: Lib v1→v2 切り替え時に App の無効化確認ダイアログが出る
- [ ] Stable/Consumer: v1.0.0→v1.1.0 切り替えで Consumer はそのまま ACTIVE
- [ ] Optional: Consumer 有効化 → Provider が自動起動、Provider 詳細に Consumer が表示