### PR TITLE
 feat: add /kairo:addons custom command

### DIFF
--- a/ACTIVATION_SPEC.md
+++ b/ACTIVATION_SPEC.md
@@ -378,6 +378,7 @@ enum InactiveReasonCode {
   // Resolution-generated reasons（Resolution 開始時にリセット）
   DEPENDENCY_INACTIVE  = "DEPENDENCY_INACTIVE",
   ADDON_ID_CONFLICT    = "ADDON_ID_CONFLICT",
+  CONFLICTS_WITH       = "CONFLICTS_WITH",     // cross-addonId conflicts 宣言による競合
   PRERELEASE_ONLY      = "PRERELEASE_ONLY",
 }
 
@@ -428,9 +429,10 @@ type ResolutionContext = {
   // Step 3 で DependencyResolver が同時に構築する解決済み逆グラフ（scope-local）
   // Step 4 BFS と Activation failure cascade（Resolution 直後）に使用
   resolvedReverseDependencyGraph: Map<KairoId, Set<KairoId>>;
-  unresolvedQueue:        KairoId[];
-  conflictGroups:         Map<AddonId, Set<KairoId>>;
-  activationPlan:         ActivationPlan;
+  unresolvedQueue:           KairoId[];
+  conflictGroups:            Map<AddonId, Set<KairoId>>;         // 同一 addonId 競合グループ
+  crossAddonConflictPairs:   Array<[KairoId, KairoId]>;          // conflicts 宣言由来の競合ペア
+  activationPlan:            ActivationPlan;
 };
 ```
 
@@ -489,6 +491,7 @@ function canActivate(
   if (runtime.state !== AddonState.INACTIVE)                                  return false;
   if (runtime.inactiveReasons.has(InactiveReasonCode.ACTIVATION_TIMEOUT))    return false;
   if (runtime.inactiveReasons.has(InactiveReasonCode.ADDON_ID_CONFLICT))     return false;
+  if (runtime.inactiveReasons.has(InactiveReasonCode.CONFLICTS_WITH))        return false;
   if (runtime.inactiveReasons.has(InactiveReasonCode.PRERELEASE_ONLY))       return false;
   if (runtime.inactiveReasons.has(InactiveReasonCode.MANUALLY_DEACTIVATED))  return false;
   // CASCADE_DEACTIVATED はブロックしない（条件が整えば自動復帰）
@@ -520,6 +523,7 @@ reasons は「いつ生成されるか」によって2種類に分類する。
 |---|---|
 | PRERELEASE_ONLY | Resolution Step 3 |
 | ADDON_ID_CONFLICT | Resolution Step 6 |
+| CONFLICTS_WITH | Resolution Step 6 |
 | DEPENDENCY_INACTIVE | Resolution Step 3 / Activation Phase |
 | DEPENDENCY_NOT_FOUND | Resolution Step 3 |
 | VERSION_NOT_SATISFIED | Resolution Step 3 |
@@ -541,6 +545,7 @@ for each runtime in scope:
   // resolution-generated inactive reasons を削除
   remove PRERELEASE_ONLY from inactiveReasons
   remove ADDON_ID_CONFLICT from inactiveReasons
+  remove CONFLICTS_WITH from inactiveReasons
   remove DEPENDENCY_INACTIVE from inactiveReasons
 
 保持:
@@ -637,6 +642,23 @@ semver の build メタデータ（`+` 以降）は完全に無視する。
 - optional 依存先が `UNRESOLVED` の場合 → 無視する
 - optional の循環依存: `UNRESOLVED` にはしない（ユーザーの責任）
   - ただし循環に巻き込まれた optional 依存先は起動しない
+
+### conflicts（競合宣言）
+
+- `AddonProperties` および `KairoRegistry` の両方に `conflicts` フィールドを追加する
+- `conflicts: { "other-addon": "^1.0.0" }` のように addonId とバージョン範囲で宣言する
+- バージョン範囲は `dependencies` と同じ記法を使用する
+- 宣言したアドオンと指定先アドオンは同時に `ACTIVE` にできない
+- **初期 activation では両者とも `INACTIVE`**（自動選択なし。ユーザーが手動で選択する）
+- `dependencies` と異なり「共存しない」という宣言であり、依存先不在でも起動は妨げない
+- UI のアドオン詳細画面に競合相手の一覧を表示する
+
+```typescript
+// 例：b-manager が a-manager の置き換えとして宣言する
+conflicts: { "a-manager": "*" }
+// startup では a-manager も b-manager も INACTIVE（CONFLICTS_WITH）になる
+// ユーザーが手動でどちらかを activate する
+```
 
 ### ~~peer~~（削除済み）
 
@@ -767,10 +789,11 @@ while queue is not empty:
 
 ---
 
-### Step 5: addonId conflict detection（detect のみ）
+### Step 5: conflict detection（detect のみ）
 
-責務: 同一 addonId のグループを作る。状態・reasons は変更しない。
+責務: 競合グループを作る。状態・reasons は変更しない。
 
+**[1] 同一 addonId 競合**
 ```
 同一 addonId でグルーピング
 
@@ -781,11 +804,22 @@ group size > 1（競合あり）:
   conflict group として Resolution ローカルに保存
 ```
 
+**[2] cross-addonId 競合（conflicts 宣言）**
+```
+for each addon A in scope:
+  for each (targetAddonId, versionRange) in A.registry.conflicts:
+    candidates = scope 内の targetAddonId を持つ addon のうち
+                 versionMatcher(versionRange, addon.version) == true のもの
+    for each B in candidates:
+      ctx.crossAddonConflictPairs.push([A, B])
+      // 重複ペア (B, A) が既に追加されていても両側宣言として Step 6 で正しく処理される
+```
+
 ---
 
 ### Step 6: conflict resolution（deterministic tiebreak）
 
-責務: Step 5 で保存された conflict group を以下の優先順で解消する。
+責務: Step 5 で保存された conflict group および conflict pair を以下の優先順で解消する。
 
 ```
 for each conflict group:
@@ -817,6 +851,20 @@ for each conflict group:
 **winner の state は変更しない**（INACTIVE のまま、activation plan で起動される）。
 loser は `setInactive(ADDON_ID_CONFLICT)` により除外される。
 conflict は `ADDON_ID_CONFLICT` reason によってのみ表現する。
+
+**[2] cross-addonId conflict pair の解消**
+
+初期 activation では自動選択を行わない。ユーザーが手動で選択する。
+`CONFLICTS_WITH` reason の `related` フィールドに競合相手の addonId を格納する（UI 表示用）。
+
+```
+for each conflict pair (A, B):
+  setInactive(A, { code: CONFLICTS_WITH, message: "...", related: [B.addonId] })
+  setInactive(B, { code: CONFLICTS_WITH, message: "...", related: [A.addonId] })
+  // 両者とも INACTIVE。activation plan には含めない。
+  // ACTIVE だった場合も setInactive で確実に落とす。
+  // 前回セッションで A が ACTIVE だったとしても、conflict 検出が優先される。
+```
 
 ---
 
@@ -938,9 +986,13 @@ manual activate は **world-wide resolution を再実行しない**。
 ```
 subgraph =
   dependency closure of targetAddon（registry spec を再帰的に辿る。versionMatcher で範囲外を除外）
-  + 全 closure ノードの same addonId グループ（conflict 検出のため）
+  + 全 closure ノードの same addonId グループ（addonId conflict 検出のため）
   + 各 same addonId グループの currently ACTIVE なバージョン（scope に含めることで mutate 許可とする）
+  + targetAddon の conflicts 宣言に該当する ACTIVE なアドオン（scope に含めることで deactivate を許可）
 ```
+
+conflicts 相手を scope に含めることで、手動 activate 時に競合相手が ACTIVE なままになる事態を防ぐ。
+Step 6 の cross-addonId conflict 解消ロジックが競合相手を `setInactive(CONFLICTS_WITH)` できるようになる。
 
 **scope に入れた addon は mutate してよい。** ACTIVE な競合バージョンを scope に明示的に含めることで、`setInactive(CASCADE_DEACTIVATED)` が scope isolation 違反にならない。
 
@@ -959,6 +1011,40 @@ activate(targetAddon):
 **重要: scope isolation の副作用**
 scope 外のアドオン（subgraph に含まれなかったもの）は一切変更しない。
 例えば scope 内の addon A が UNRESOLVED になっても、scope 外で A に依存している addon X はそのまま ACTIVE のままになる。これは仕様上の制約であり、意図的な設計である（manual activate は世界全体の依存を修復しない）。
+
+---
+
+## conflicts × Manual Activate
+
+### 初期状態
+
+startup activation で conflict が検出された場合、競合する両アドオンは `INACTIVE`（`CONFLICTS_WITH`）になる。
+ユーザーが UI で明示的にどちらかを選択するまで両方 INACTIVE のまま。
+
+### ユーザーがどちらかを手動 activate する場合
+
+**ケース 1: A を activate（B は INACTIVE）**
+```
+通常の manual activate フローを実行。
+B は INACTIVE（CONFLICTS_WITH）のまま変化しない。
+```
+
+**ケース 2: A が ACTIVE の状態で B を activate しようとした場合**
+```
+UI: B の Apply フォームで確認ダイアログを表示
+  「B は [A] と競合しています。有効化すると [A] は無効になります。続けますか？」
+
+ユーザーがキャンセル → 何もしない
+
+ユーザーが確認 →
+  1. A を deactivate（CASCADE_DEACTIVATED）
+  2. A に依存するアドオンを cascade deactivate（通常の cascade deactivate と同様）
+  3. B の subgraph resolution → activation 実行
+```
+
+### conflicts 解消後の再 activate
+
+A を deactivate して B を activate した後、ユーザーが再度 A を activate したい場合は通常の manual activate フローが使用できる（CONFLICTS_WITH は Resolution 開始時にリセットされ、再評価される）。
 
 ---
 

--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1,0 +1,580 @@
+# Kairo API Spec
+
+アドオン間通信（router ↔ router）を kairo が仲介する機能の仕様書。
+
+---
+
+## 概要
+
+Minecraft Script API はグローバルな名前空間しかなく、アドオン間で直接関数呼び出しができない。
+kairo が ScriptEvent を使ったルーティング層を提供することで、アドオンが互いの API を呼び出せるようにする。
+
+呼び出し元は相手の addonId と API 名だけ知っていれば良く、kairoId や ScriptEvent の詳細は意識しない。
+
+---
+
+## router 側 API（アドオン開発者向け）
+
+### API の提供・hook 宣言
+
+`register` と `hook` は `router.beforeEvents.startup` の `ev.api` 経由でのみ呼び出せる。
+startup イベント終了後に呼ぼうとするとエラー。
+
+```typescript
+ev.api.register<TArgs, TReturn>(apiName: string, handler: (args: TArgs) => TReturn | Promise<TReturn>): void
+ev.api.hook<TArgs, TReturn>(targetAddonId: string, apiName: string, options: HookOptions<TArgs, TReturn>): void
+```
+
+- `addonId` は router のコンテキストから暗黙的に取得されるため指定不要。
+- handler が実際に呼び出し可能になるのは activation 後。startup 段階ではまだ呼べない。
+- 同一 addonId 内で同一 `apiName` を重複 `register` するとエラー。
+
+```typescript
+// 例
+router.beforeEvents.startup.subscribe((ev) => {
+    ev.customCommandRegistry.registerCommand(...);
+
+    ev.api.register<{ playerId: string }, { balance: number }>(
+        "economy/getBalance",
+        async ({ playerId }) => ({ balance: 100 }),
+    );
+
+    ev.api.hook<{ amount: number }, void>("other-addon", "economy/deposit", {
+        priority: -10,
+        before: async (ctx) => {
+            if (ctx.args.amount < 0) ctx.cancel();
+        },
+    });
+});
+```
+
+### API の呼び出し
+
+```typescript
+// fire-and-forget（返答を待たない）
+router.send(targetAddonId: string, apiName: string, args?: unknown): void
+
+// 結果を待つ（Promise）
+router.request<TReturn>(
+    targetAddonId: string,
+    apiName: string,
+    args?: unknown,
+    options?: { timeout?: number }  // タイムアウト（tick）。デフォルト 20 tick。
+): Promise<TReturn | CancelledResult>
+```
+
+- `targetAddonId`: 呼び出し先アドオンの addonId（kairoId ではない）。
+
+**`send` のエラー挙動（すべてスルー）**
+- 対象 addonId が存在しない / inactive / unresolved でも無視する。
+- API 名が存在しない場合も無視する。
+- hook でキャンセルされても呼び出し元には伝わらない。
+- hook が例外をスローしても caller には伝播しない。ただし kairo は内部でログ出力すること（SHOULD）。
+- ハンドラが例外をスローしても caller には伝播しない。同様にログ出力すること（SHOULD）。
+- **順序保証なし**: 複数の `send` を連続して呼んだ場合、ScriptEvent の配送順は保証されない。順序依存の設計は避けること。
+
+**`request` のエラー評価順序（この順で判定し、最初にマッチした結果を返す）**
+
+| 順序 | チェック内容 | 挙動 |
+|---|---|---|
+| 1 | 対象 addonId がルーティングテーブルに存在しない | `{ cancelled: true, reason: "ADDON_NOT_FOUND" }` |
+| 2 | 対象 addonId の active インスタンスが inactive | `{ cancelled: true, reason: "ADDON_INACTIVE" }` |
+| 3 | 対象 addonId の active インスタンスが unresolved | `{ cancelled: true, reason: "ADDON_UNRESOLVED" }` |
+| 4 | apiName がルーティングテーブルに存在しない | Promise reject（`ApiNotFoundError`） |
+| 5 | hook が例外をスロー | Promise reject（`HookExecutionError`）。cancel とは別扱い |
+| 6 | hook により cancel された | `{ cancelled: true, reason: "CANCELLED_BY_HOOK" }` |
+| 7 | ハンドラが例外をスロー | Promise reject（`HandlerExecutionError`） |
+| 8 | タイムアウト | Promise reject（`RequestTimeoutError`） |
+
+> 評価順序が確定しているため、アドオンが inactive の場合は API の存在チェックに到達しない。
+> "API_NOT_FOUND" と "ADDON_INACTIVE" が競合することはない。
+> hook の throw は cancel ではなく failure として扱う（cancel ≠ failure）。
+
+```typescript
+type CancelledResult = {
+    readonly cancelled: true;
+    readonly reason: "ADDON_NOT_FOUND" | "ADDON_INACTIVE" | "ADDON_UNRESOLVED" | "CANCELLED_BY_HOOK";
+};
+
+// request が Promise reject する場合の Error 型（instanceof で分類可能）
+class ApiNotFoundError    extends Error {}  // API 名がルーティングテーブルに存在しない
+class RequestTimeoutError extends Error {}  // タイムアウト
+class HookExecutionError  extends Error {}  // hook が例外をスロー
+class HandlerExecutionError extends Error {}// ハンドラが例外をスロー
+```
+
+```typescript
+// 例
+router.send("economy-addon", "onTransaction", { amount: 50 });
+
+const result = await router.request<{ balance: number }>("economy-addon", "getBalance", { playerId: "..." });
+if ("cancelled" in result) {
+    // キャンセルされた場合
+    console.log(result.reason);
+} else {
+    console.log(result.balance);
+}
+
+// タイムアウトを延長したい場合
+const result = await router.request("economy-addon", "heavyCalc", args, { timeout: 100 });
+```
+
+### API の hook
+
+`ev.api.hook()` の詳細仕様（startup イベント内でのみ呼び出せる）。
+
+```typescript
+type HookOptions<TArgs, TReturn> = {
+    priority?: number;
+    version?: string;  // 将来的なバージョン指定用。現時点では未使用
+    before?: (ctx: BeforeHookContext<TArgs, TReturn>) => Promise<void>;
+    after?: (ctx: AfterHookContext<TArgs, TReturn>) => Promise<void>;
+};
+```
+
+- `before` / `after` は両方省略不可（少なくとも片方が必要）。
+- `priority`: 32-bit 符号付き整数（`-2^31` 〜 `2^31 - 1`）。小さいほど先に実行される。省略時は `0`。
+- **同値の tie-break**: `priority asc → sequence asc`。sequence number は Registration phase finalized 時点で kairo が **addonId 辞書順** に採番する。ScriptEvent 到着順に依存しないため完全 deterministic。addonId 順は永続的に固定されるため、同一 priority の hook 順を制御したい場合は priority を使うこと。
+- `targetAddonId` に対する dependency 宣言は不要。
+- 対象アドオンが inactive なら hook は無視される。
+- **opt-out モデル**: `before` 内で `ctx.cancel()` を呼ばない限り自動的に次へ進む。
+- **cancel の伝播**: `ctx.cancel()` が呼ばれると、それ以降の hook（`before` / `after` 両方）とハンドラはすべてスキップされる。
+- **hook throw の semantics（request）**: `before` hook が例外をスローした場合、その call は即座に abort する（ハンドラは実行しない）。成功済みの `before` hook に対応する **`rollback`** を逆順で実行する（`after` ではない。result が存在しないため）。`HookExecutionError` で reject。
+  ```
+  before #1 成功 → stack に push（args_1 をスナップショット）
+  before #2 成功 → stack に push（args_2 をスナップショット）
+  before #3 throw
+  → rollback #2（args = args_2）
+  → rollback #1（args = args_1）
+  → handler は実行しない
+  ```
+- **hook throw の semantics（send）**: `before` hook が例外をスローした場合、ログ出力して即 drop（それ以降の hook もハンドラも実行しない）。rollback は不要（fire-and-forget のため caller が存在しない）。
+- **`send` に対する hook**: `before` のみ有効。`after` は `send` では実行されない（fire-and-forget のためハンドラ応答がなく after フェーズが存在しない）。
+- **`before` での `ctx.result` 設定**: `cancel()` と組み合わせた場合のみ有効（ハンドラをスキップして設定した値を返す）。`cancel()` なしで設定してもハンドラの戻り値に上書きされる。
+- **前方参照 hook（forward hook）**: 対象 API がまだ manifest に含まれていない場合は、Registration phase finalized 時に照合する。
+
+**実行順序（オニオンモデル）: `after` は `before` の逆順**
+```
+before: priority -10 → 0 → 5 → handler → after: 5 → 0 → -10
+```
+
+```typescript
+router.beforeEvents.startup.subscribe((ev) => {
+    // 例：前処理のみ（args 改ざん）
+    ev.api.hook("addon-a", "test", {
+        before: async (ctx) => {
+            ctx.args = { ...ctx.args, injected: true };
+        },
+    });
+
+    // 例：キャンセル
+    ev.api.hook("addon-a", "test", {
+        before: async (ctx) => {
+            if (ctx.args.forbidden) ctx.cancel();
+        },
+    });
+
+    // 例：ハンドラをスキップして自前の結果を返す
+    ev.api.hook("addon-a", "economy/getBalance", {
+        before: async (ctx) => {
+            const cached = cache.get(ctx.args.playerId);
+            if (cached) {
+                ctx.result = cached;
+                ctx.cancel();
+            }
+        },
+    });
+
+    // 例：後処理（result 改ざん）
+    ev.api.hook("addon-a", "economy/getBalance", {
+        after: async (ctx) => {
+            ctx.result = { ...ctx.result, taxApplied: true };
+        },
+    });
+
+    // 例：前処理 + 後処理（ローカル変数共有はクロージャで）
+    function createTimingHook() {
+        let startTime: number;
+        return {
+            priority: 5,
+            before: async (_ctx: unknown) => { startTime = Date.now(); },
+            after:  async (_ctx: unknown) => { console.log(Date.now() - startTime); },
+        };
+    }
+    ev.api.hook("addon-a", "test", createTimingHook());
+});
+```
+
+---
+
+## HookContext
+
+フェーズ別に3つの型が存在する。
+
+```typescript
+// before フェーズ：ハンドラ実行前
+type BeforeHookContext<TArgs, TReturn> = {
+    args: TArgs;                    // 変更可能（改ざん可）
+    result: TReturn | undefined;    // cancel() と組み合わせてハンドラをスキップして結果を返せる
+    readonly callerAddonId: string;
+    cancel(): void;                 // 明示的キャンセル。以降の hook / ハンドラを実行しない
+};
+
+// after フェーズ：ハンドラ実行後（request のみ。send には after フェーズが存在しない）
+type AfterHookContext<TArgs, TReturn> = {
+    readonly args: Readonly<TArgs>; // shallow readonly。ネストされたオブジェクトの mutate は undefined behavior
+    result: TReturn;                // 必ず値あり（変更可）
+    readonly callerAddonId: string;
+    // cancel() なし（ハンドラはすでに実行済み）
+};
+
+// rollback フェーズ：before hook が例外をスローした時のみ発火（request のみ）
+// handler は実行されていないため result が存在しない。after とは別物。
+type HookRollbackContext<TArgs> = {
+    readonly args: Readonly<TArgs>; // この hook の before 実行終了時点の args スナップショット
+    readonly callerAddonId: string;
+};
+```
+
+### cancel() の挙動
+
+```
+ctx.result が設定済み → その result を呼び出し元に返す（成功扱い）
+ctx.result が未設定   → { cancelled: true, reason: "CANCELLED_BY_HOOK" } を返す
+```
+
+### rollback の args スナップショット
+
+rollback が受け取る `args` は、**その hook 自身の before 実行が終了した時点の args**。
+複数 before hook が args を順に改ざんしていた場合、各 rollback はそれぞれ自分が残した値を見る。
+
+```
+before A: args → args_A（args_A をスナップショット）
+before B: args_A → args_B（args_B をスナップショット）
+before C: throw
+
+rollback B: args = args_B
+rollback A: args = args_A
+```
+
+---
+
+---
+
+## API Declaration Phase
+
+### 全体フロー
+
+```
+startup イベント（worldLoad より前）
+  └ router.register() / router.hook() → router 内にローカル保持（kairoId 未割り当て）
+
+worldLoad
+  └ Discovery → Registration
+       └ Registration 成功時: RegistrationResponse に API manifest を同梱して送信
+
+全 Registration 完了後（kairo 側）
+  └ ルーティングテーブル構築
+  └ forward hook の照合・検証
+
+Activation 開始
+  └ handler が実際に呼び出し可能になる
+```
+
+### 宣言タイミング（startup イベント）
+
+Minecraft の `startup` イベント（`worldLoad` より前に発火）で `register` / `hook` を呼ぶ。
+この時点では kairoId がまだ割り当てられていないため、宣言は router 内にローカル保持される。
+
+```typescript
+// startup イベント内（worldLoad より前）
+router.beforeEvents.startup.subscribe((ev) => {
+    ev.api.register<{ playerId: string }, { balance: number }>(
+        "economy/getBalance",
+        async ({ playerId }) => ({ balance: 100 }),
+    );
+    ev.api.hook("other-addon", "economy/deposit", {
+        before: async (ctx) => { /* ... */ },
+    });
+    // Minecraft カスタムコマンドも同じ場所で登録できる
+    ev.customCommandRegistry.registerCommand(...);
+});
+```
+
+### Manifest 送信（Registration 成功後）
+
+Registration が成功してアドオンが `kairoId` を得た直後、router は API manifest を kairo に送信する。
+manifest は `RegistrationResponse` に含めて送信する（追加フェーズは設けない）。
+
+```
+manifest 内容:
+  - 提供 API 一覧: [{ name: "economy/getBalance" }, ...]
+  - hook 宣言一覧: [{ targetAddonId: "economy-addon", apiName: "economy/getBalance", priority: 0, phases: ["before"] }, ...]
+  ※ version は将来用フィールドのため manifest には含めない（HookOptions には存在するが wire format に載せない）
+```
+
+### kairo 側での管理（全 Registration 完了後）
+
+kairo は全アドオンの Registration が完了した時点でルーティングテーブルを構築する。
+
+```
+ルーティングテーブル:
+  "economy-addon" → {
+      "getBalance" → kairoId_A,
+      "deposit"    → kairoId_A,
+  }
+
+フック登録テーブル:
+  "economy-addon::getBalance" → [
+      { kairoId: kairoId_B, priority: 0, phases: ["before"] },
+      { kairoId: kairoId_C, priority: 10, phases: ["before", "after"] },
+  ]
+```
+
+前方参照（まだ manifest が届いていない addonId を hook しようとしているケース）は、
+**Registration phase finalized（登録フェーズのタイムアウト完了時点）** に照合する。
+一部の Registration が失敗してもフェーズは終了する。
+存在しない API への hook は警告ログを出力して無視する。
+
+### 重複登録
+
+```
+同一アドオンが同一 apiName で register を2回呼んだ場合 → Error をスロー
+異なる addonId が同一 apiName で register した場合 → 許可（addonId で識別）
+```
+
+---
+
+## kairo 本体側の hook API
+
+kairo 本体は全アドオンの API 呼び出しをルーティングするため、横断的な hook を設定できる。
+用途: ロギング、レート制限、認可チェックなど。
+登録タイミング: kairo の初期化時（Activation Phase 開始前）。
+
+```typescript
+// kairo 本体側（packs/kairo 内）
+kairo.api.hook("economy-addon", "getBalance", {
+    priority: -100,  // 全アドオンの hook より先に実行したい場合は小さい値
+    before: async (ctx) => { /* ロギング */ },
+    after:  async (ctx) => { /* ロギング */ },
+});
+```
+
+インターフェースは `router.hook` と同一。kairo は特別な priority 制約を受けない。
+
+---
+
+---
+
+## プロトコル（内部実装・ユーザー不可視）
+
+ScriptEvent を使って kairo ↔ router 間で通信する。ユーザーは `router.send()` / `router.request()` を呼ぶだけでよい。
+メッセージは `JSON.stringify` でシリアライズする。パフォーマンスが必要な場合は `fast-json-stringify` を推奨するが必須ではない。
+スキーマ定義は TypeBox を使用する（kairo 内部の慣習に合わせる）。
+
+### ScriptEvent ID 体系
+
+| 方向 | Event ID | 用途 |
+|---|---|---|
+| Router → Kairo | `kairo:api-call` | send / request の呼び出し |
+| Kairo → Router（ハンドラ側） | `{kairoId}:api-invoke` | ハンドラへの実行指示 |
+| Router（ハンドラ）→ Kairo | `kairo:api-response` | ハンドラの結果返送 |
+| Kairo → Router（呼び出し元） | `{correlationId}:api-result` | request の最終結果返送 |
+
+### メッセージスキーマ
+
+```typescript
+// Router → Kairo: API 呼び出し開始
+// callerKairoId は payload に含めない。kairo が ScriptEvent の送信元から実 kairoId を確定する。
+// correlationId 形式は opaque（内部実装の詳細）。呼び出し元 router が一意性を保証する責務を持つ。
+const ApiCallSchema = Type.Object({
+    type:          Type.Union([Type.Literal("send"), Type.Literal("request")]),
+    correlationId: Type.String(),   // request のみ使用。send は空文字
+    targetAddonId: Type.String(),
+    apiName:       Type.String(),
+    args:          Type.String(),   // JSON.stringify(args)
+    timestamp:     Type.Integer({ minimum: 0 }),
+});
+
+// Kairo → Router（ハンドラ側）: 実行指示
+const ApiInvokeSchema = Type.Object({
+    type:          Type.Union([Type.Literal("send"), Type.Literal("request")]),
+    correlationId: Type.String(),
+    callerAddonId: Type.String(),   // kairoId ではなく addonId（ユーザー向け）
+    apiName:       Type.String(),
+    args:          Type.String(),   // hook after フェーズで改ざんされた後の値
+    timestamp:     Type.Integer({ minimum: 0 }),
+});
+
+// Router（ハンドラ）→ Kairo: ハンドラ結果（request のみ）
+// kairoId は含めない。kairo が ScriptEvent 送信元から誰の応答か確定する（spoofing 防止）。
+const ApiHandlerResponseSchema = Type.Object({
+    correlationId: Type.String(),
+    success:       Type.Boolean(),
+    result:        Type.Optional(Type.String()),  // JSON.stringify(result)。success=true のみ
+    error:         Type.Optional(Type.String()),  // エラーメッセージ。success=false のみ
+    timestamp:     Type.Integer({ minimum: 0 }),
+});
+
+// Kairo → Router（呼び出し元）: 最終結果（request のみ）
+// success=true  → result あり
+// success=false, cancelled=true → CancelledResult（アドオン状態・hook cancel）
+// success=false, errorType あり → failure（hook/handler 例外・API 不存在）
+const ApiResultSchema = Type.Object({
+    correlationId: Type.String(),
+    success:       Type.Boolean(),
+    result:        Type.Optional(Type.String()),          // success=true のみ。JSON.stringify(result)
+    cancelled:     Type.Optional(Type.Literal(true)),     // success=false + cancelled 時
+    reason:        Type.Optional(Type.String()),          // cancelled 時の CancelledResult reason
+    errorType:     Type.Optional(Type.Union([             // success=false + failure 時
+        Type.Literal("API_NOT_FOUND"),
+        Type.Literal("HOOK_EXECUTION"),
+        Type.Literal("HANDLER_EXECUTION"),
+    ])),
+    error:         Type.Optional(Type.String()),          // エラーメッセージ
+    timestamp:     Type.Integer({ minimum: 0 }),
+});
+
+// Registration 時に router が送る API manifest（RegistrationResponse に追加）
+// version は HookOptions に存在するが wire format には含めない（将来追加予定）
+const ApiManifestSchema = Type.Object({
+    apis: Type.Array(Type.Object({
+        name: Type.String(),
+    })),
+    hooks: Type.Array(Type.Object({
+        targetAddonId: Type.String(),
+        apiName:       Type.String(),
+        priority:      Type.Integer({ minimum: -2147483648, maximum: 2147483647 }),
+        phases:        Type.Array(Type.Union([Type.Literal("before"), Type.Literal("after"), Type.Literal("rollback")])),
+    })),
+});
+```
+
+### errorType → Error class 変換（router 側）
+
+kairo から `ApiResult.errorType` を受け取った router は以下のように JS Error に変換して reject する：
+
+| `errorType` | reject する Error クラス |
+|---|---|
+| `"API_NOT_FOUND"` | `new ApiNotFoundError()` |
+| `"HOOK_EXECUTION"` | `new HookExecutionError()` |
+| `"HANDLER_EXECUTION"` | `new HandlerExecutionError()` |
+```
+
+### 責務分担
+
+```
+router（呼び出し元）: timeout 管理のみ
+kairo:               routing state / pending correlation map 管理
+```
+
+### request のフロー
+
+```
+1. Router(B) が correlationId を生成
+     形式は opaque（内部実装の詳細。UUID 等、一意性は router が保証）
+2. Router(B) が ApiCall を送信 + timeout タイマーをセット（デフォルト 20 tick / options.timeout で変更可）
+3. kairo が ApiCall を受信:
+     callerKairoId = ScriptEvent 送信元から確定（payload からは取得しない）
+     対象アドオンの状態をこの時点でスナップショット（routing チェック専用。存在確認・activation 状態確認に使用）
+     ※ invoke 送信後の deactivate は snapshot とは独立した terminal event として扱う（下記参照）
+     pending map に追加: { correlationId, callerKairoId, targetKairoId }
+     hook テーブルの sequence number は Registration phase finalized 時に addonId 辞書順で確定済み
+4. kairo が hook before を実行
+5. kairo が ApiInvoke を Router(A) に送信
+6. Router(A) がハンドラを実行し ApiHandlerResponse を返す
+7. kairo が hook after を実行
+8. kairo が pending map から correlationId を削除  ← 削除を先に行う（リーク耐性）
+9. kairo が ApiResult を Router(B) に送信
+```
+
+### terminal event の競合
+
+timeout / ApiResult(result) / ApiResult(cancelled) はすべて「terminal event」。
+**先着した terminal event が Promise を確定させ、後続は破棄する。**
+
+```
+Router(B) 側:
+  correlationId が pending に存在する → 処理
+  correlationId が pending にない（すでに resolved）→ 無視
+
+Timeout 到達時:
+  → Router(B) が Promise を reject（RequestTimeoutError）
+  → Router(B) が correlationId を pending から削除
+  → 以降 ApiResult が届いても Router(B) は無視
+
+ApiResult 先着時:
+  → Router(B) が Promise を resolve/reject
+  → Router(B) が correlationId を pending から削除
+  → timeout が後から発火しても Router(B) は無視
+```
+
+**timeout はハンドラの実行を中断しない。**
+timeout が発火した時点で caller 側の待機はキャンセルされるが、Router(A) のハンドラは実行を継続する。
+ハンドラが後から応答を返しても kairo は pending から correlationId が消えているため破棄する。
+
+### deactivate race condition
+
+```
+step 5〜7 実行中に対象アドオンが deactivate された場合:
+
+  deactivate first wins:
+    → kairo が pending map から correlationId を削除（削除を先に行う）
+    → kairo が Router(B) に ApiResult を送信: { cancelled: true, reason: "ADDON_INACTIVE" }
+    → 後から Router(A) の ApiHandlerResponse が届いても kairo は破棄する
+      （pending map に correlationId がないため）
+
+  ※ invoke 開始前（step 4 以前）の deactivate は routing チェック（snapshot）で ADDON_INACTIVE として
+    pending に追加される前に弾かれる。invoke 後の deactivate のみこの経路に入る。
+
+  ApiHandlerResponse 受信後の deactivate:
+    kairo が ApiHandlerResponse を受信した時点で結果は確定（committed）。
+    その後 deactivate が届いても after hook の実行と ApiResult の送信は続行する。
+    deactivate は「次回の routing チェックから inactive 扱い」になるのみ。
+```
+```
+
+---
+
+---
+
+## 運用ガイドライン
+
+### API 名の名前空間
+
+API 名にスラッシュ区切りの名前空間を付けることを推奨する。同一 addonId 内の衝突を防ぐだけでなく、
+hook 時の検索性が上がる。
+
+```typescript
+// 推奨
+router.register("economy/getBalance", handler);
+router.register("economy/deposit", handler);
+router.register("player/getInfo", handler);
+
+// 非推奨（将来の名前衝突リスク）
+router.register("getBalance", handler);
+```
+
+---
+
+## 未確定事項
+
+現時点でなし。
+
+---
+
+## 設計方針メモ
+
+- **ライブラリ非依存（public API）**: `router.register` / `router.hook` / `router.send` / `router.request` などユーザー向け API は外部ライブラリに依存しない。型安全はコンパイル時ジェネリクスのみ。
+- **TypeBox 使用可能（internal）**: kairo 内部のプロトコルスキーマ定義は TypeBox を使用してよい。ユーザーには不可視。
+- **addonId アドレッシング**: 呼び出し先は addonId で指定。kairoId は内部識別子のためユーザーに露出しない。callerKairoId は payload に含めず kairo が ScriptEvent 送信元から確定する（spoofing 防止）。
+- **startup declaration**: `ev.api.register()` / `ev.api.hook()` は `router.beforeEvents.startup` コールバック内でのみ有効。`ev.api` は startup 終了後に seal される。handler は activation 後に使用可能になる。
+- **hook の実行順序**: priority 数値昇順（任意の整数、省略時 0）。同値は registration 順（manifest 受信順）。after はオニオンモデル（before の逆順）。send に after フェーズはない。
+- **責務分担**: router はタイムアウト管理のみ。kairo は routing state / pending correlation map を保持する。terminal event（timeout / result / cancelled）は先着したものが Promise を確定させ、後続は破棄する。pending 削除は ApiResult 送信より先に行う（リーク耐性）。
+- **timeout はハンドラを止めない**: timeout 到達時は caller の待機がキャンセルされるのみ。handler の実行は継続する。
+- **send のエラーは caller に伝播しない**: hook/handler の例外は kairo が内部ログに出力する（SHOULD）。caller には何も返らない。
+- **after の args mutate は undefined behavior**: `ctx.args` は shallow readonly のみ。ネストオブジェクトの改ざんは未定義動作。
+- **hook throw → unwind**: before hook 例外発生時は handler を実行せず、成功済み before に対応する after のみ逆順で実行する。
+- **ApiHandlerResponse 受信後は結果 committed**: deactivate が後から届いても after 実行と ApiResult 送信は継続する。
+- **sequence number は addonId 辞書順**: Registration phase finalized 時点で採番。ScriptEvent 到着順に依存しない。
+- **`conflicts` 宣言**: ACTIVATION_SPEC.md に記載済み。API hook とは別レイヤー（lifecycle レベル）の機能。

--- a/src/kairo/Kairo.ts
+++ b/src/kairo/Kairo.ts
@@ -1,15 +1,14 @@
 import { KairoRouter, router } from "@kairo-js/router";
-import { SeedRandom } from "@kairo-js/utils";
-import { system } from "@minecraft/server";
+import { SeedRandom, SemVerUtils } from "@kairo-js/utils";
+import { CommandPermissionLevel, CustomCommandParamType, CustomCommandStatus, system } from "@minecraft/server";
 import type { Player } from "@minecraft/server";
+import { AddonState } from "./activation/types/state";
 import { KairoRuntime } from "../minecraft/KairoRuntime";
 import { ActivationController } from "./activation/ActivationController";
 import { KairoError, KairoErrorReason } from "./errors/KairoError";
 import { KairoInitializer } from "./init/KairoInitializer";
 import { KairoRegistryIndex } from "./KairoRegistryIndex";
 import { KairoUI } from "./ui/KairoUI";
-
-const UI_TRIGGER_ITEM = "minecraft:nether_star";
 
 class Kairo {
     private runtime?: KairoRuntime;
@@ -33,10 +32,158 @@ class Kairo {
             initializer.setup();
             initializer.onWorldLoad();
         });
+
+        this.router.beforeEvents.startup.subscribe(ev => {
+            ev.customCommandRegistry.registerEnum("kairo:addons_subcommand", ["list", "open", "enable", "disable", "status"]);
+            ev.customCommandRegistry.registerCommand(
+                {
+                    name: "kairo:addons",
+                    description: "Manages Kairo addons",
+                    cheatsRequired: false,
+                    permissionLevel: CommandPermissionLevel.GameDirectors,
+                    mandatoryParameters: [
+                        { name: "kairo:addons_subcommand", type: CustomCommandParamType.Enum },
+                    ],
+                    optionalParameters: [
+                        { name: "addonId", type: CustomCommandParamType.String },
+                        { name: "version", type: CustomCommandParamType.String },
+                    ],
+                },
+                (origin, subcommand, addonId?, version?) => {
+                    const player = origin.sourceEntity as Player;
+                    if (subcommand === "list") {
+                        system.run(() => { this.commandList(player); });
+                    } else if (subcommand === "open") {
+                        system.run(() => { this.ui?.open(player); });
+                    } else if (subcommand === "enable" && addonId && version) {
+                        system.run(() => { void this.commandEnable(addonId as string, version as string); });
+                    } else if (subcommand === "disable" && addonId) {
+                        if (addonId === "kairo") {
+                            return { status: CustomCommandStatus.Failure, message: "Kairo cannot be disabled. Use 'enable' to switch versions." };
+                        }
+                        system.run(() => { void this.commandDisable(addonId as string); });
+                    } else if (subcommand === "status" && addonId) {
+                        system.run(() => { this.commandStatus(player, addonId as string); });
+                    }
+                    return { status: CustomCommandStatus.Success };
+                },
+            );
+        });
     }
 
     openUI(player: Player): void {
         this.ui?.open(player);
+    }
+
+    private commandList(player: Player): void {
+        if (!this.activationController) return;
+        const world = this.activationController.world;
+
+        type GroupState = "active" | "inactive" | "unresolved";
+        const STATE_PRIORITY: Record<GroupState, number> = { active: 0, inactive: 1, unresolved: 2 };
+
+        const groups: { addonId: string; state: GroupState; name: string; activeVersion?: string }[] = [];
+        for (const [addonId, kairoIds] of world.addonIdIndex) {
+            let hasActive = false;
+            let hasInactive = false;
+            let activeVersion: string | undefined;
+            let name = addonId;
+
+            for (const id of kairoIds) {
+                const rt = world.runtimes.get(id);
+                const reg = world.registries.get(id);
+                if (reg) name = reg.name;
+                if (rt?.state === AddonState.ACTIVE) {
+                    hasActive = true;
+                    activeVersion = SemVerUtils.format(reg!.version);
+                    break;
+                }
+                if (rt?.state === AddonState.INACTIVE) hasInactive = true;
+            }
+
+            const state: GroupState = hasActive ? "active" : hasInactive ? "inactive" : "unresolved";
+            groups.push({ addonId, state, name, activeVersion });
+        }
+
+        groups.sort((a, b) => {
+            const stateDiff = STATE_PRIORITY[a.state] - STATE_PRIORITY[b.state];
+            if (stateDiff !== 0) return stateDiff;
+            return a.addonId.localeCompare(b.addonId);
+        });
+
+        const lines = groups.map(g => {
+            if (g.state === "active")     return `  §a${g.name} §7${g.activeVersion}`;
+            if (g.state === "unresolved") return `  §c${g.name} §7(unresolved)`;
+            return `  §e${g.name} §7(inactive)`;
+        });
+
+        const header = `§b[Kairo] §fAddons (${groups.length}):`;
+        player.sendMessage(lines.length > 0 ? `${header}\n${lines.join("\n")}` : header);
+    }
+
+    private commandStatus(player: Player, addonId: string): void {
+        if (!this.activationController) return;
+        const world = this.activationController.world;
+
+        const kairoIds = world.addonIdIndex.get(addonId);
+        if (!kairoIds || kairoIds.size === 0) {
+            player.sendMessage(`§c[Kairo] Addon "${addonId}" not found.`);
+            return;
+        }
+
+        const lines: string[] = [`§b[Kairo] §f${addonId}`];
+        for (const id of kairoIds) {
+            const reg = world.registries.get(id);
+            const rt = world.runtimes.get(id);
+            if (!reg || !rt) continue;
+            const ver = SemVerUtils.format(reg.version);
+            if (rt.state === AddonState.ACTIVE) {
+                lines.push(`  §a${ver} — ACTIVE`);
+            } else if (rt.state === AddonState.INACTIVE) {
+                const reasons = [...rt.inactiveReasons.keys()].join(", ");
+                lines.push(`  §e${ver} — INACTIVE${reasons ? ` §7(${reasons})` : ""}`);
+            } else {
+                const reasons = [...rt.unresolvedReasons.keys()].join(", ");
+                lines.push(`  §c${ver} — UNRESOLVED${reasons ? ` §7(${reasons})` : ""}`);
+            }
+        }
+        player.sendMessage(lines.join("\n"));
+    }
+
+    private async commandEnable(addonId: string, versionStr: string): Promise<void> {
+        if (!this.activationController) return;
+        const world = this.activationController.world;
+
+        const kairoIds = world.addonIdIndex.get(addonId);
+        if (!kairoIds) return;
+
+        const newKairoId = [...kairoIds].find(id => {
+            const reg = world.registries.get(id);
+            return reg ? SemVerUtils.format(reg.version) === versionStr : false;
+        });
+        if (!newKairoId) return;
+
+        const currentActiveId = [...kairoIds].find(id => world.runtimes.get(id)?.state === AddonState.ACTIVE);
+        if (currentActiveId === newKairoId) return;
+
+        if (currentActiveId) {
+            await this.activationController.executeVersionSwitch(currentActiveId, newKairoId);
+        } else {
+            await this.activationController.executeEnable(newKairoId, "explicit");
+        }
+    }
+
+    private async commandDisable(addonId: string): Promise<void> {
+        if (!this.activationController) return;
+        const world = this.activationController.world;
+
+        const kairoIds = world.addonIdIndex.get(addonId);
+        if (!kairoIds) return;
+
+        const activeId = [...kairoIds].find(id => world.runtimes.get(id)?.state === AddonState.ACTIVE);
+        if (!activeId) return;
+
+        await this.activationController.executeDisable(activeId);
     }
 
     private readonly onInitComplete = () => {
@@ -52,13 +199,6 @@ class Kairo {
             await this.activationController.startupActivate(plan);
 
             this.ui = new KairoUI(this.activationController);
-
-            // router 経由で購読 → kairo が deactivate されると自動的に解除される
-            this.router.afterEvents.itemUse.subscribe(ev => {
-                if (ev.itemStack.typeId !== UI_TRIGGER_ITEM) return;
-                const player = ev.source;
-                system.run(() => { this.ui!.open(player); });
-            });
         })();
     };
 }

--- a/src/kairo/ui/KairoUI.ts
+++ b/src/kairo/ui/KairoUI.ts
@@ -19,7 +19,7 @@ export class KairoUI {
     async open(player: Player): Promise<void> {
         const world = this.controller.world;
 
-        const selectedAddonId = await this.addonList.show(player, world, this.controller.activationOrder);
+        const selectedAddonId = await this.addonList.show(player, world);
         if (!selectedAddonId) return;
 
         // Check if all versions are UNRESOLVED

--- a/src/kairo/ui/screens/AddonListScreen.ts
+++ b/src/kairo/ui/screens/AddonListScreen.ts
@@ -2,7 +2,7 @@ import type { Player } from "@minecraft/server";
 import { ActionFormData } from "@minecraft/server-ui";
 import { SemVerUtils } from "@kairo-js/utils";
 import type { KairoWorldState } from "../../activation/types/world";
-import { AddonState, type KairoId } from "../../activation/types/state";
+import { AddonState } from "../../activation/types/state";
 import { T } from "../constants/TranslateKeys";
 
 type GroupState = "active" | "inactive" | "unresolved";
@@ -35,9 +35,8 @@ export class AddonListScreen {
     async show(
         player: Player,
         world: KairoWorldState,
-        activationOrder: readonly KairoId[],
     ): Promise<string | null> {
-        const groups = this.buildAndSortGroups(world, activationOrder);
+        const groups = this.buildAndSortGroups(world);
 
         const form = new ActionFormData()
             .title({ translate: T.addonList.title });
@@ -78,18 +77,7 @@ export class AddonListScreen {
         return groups[response.selection]?.addonId ?? null;
     }
 
-    private buildAndSortGroups(
-        world: KairoWorldState,
-        activationOrder: readonly KairoId[],
-    ): AddonGroup[] {
-        // Build addonId → earliest index in activation order
-        const orderIndex = new Map<string, number>();
-        for (let i = 0; i < activationOrder.length; i++) {
-            const reg = world.registries.get(activationOrder[i]!);
-            if (!reg) continue;
-            if (!orderIndex.has(reg.addonId)) orderIndex.set(reg.addonId, i);
-        }
-
+    private buildAndSortGroups(world: KairoWorldState): AddonGroup[] {
         const groups: AddonGroup[] = [];
 
         for (const [addonId, kairoIds] of world.addonIdIndex) {
@@ -114,11 +102,6 @@ export class AddonListScreen {
         groups.sort((a, b) => {
             const stateDiff = STATE_PRIORITY[a.state] - STATE_PRIORITY[b.state];
             if (stateDiff !== 0) return stateDiff;
-
-            const aIdx = orderIndex.get(a.addonId) ?? Infinity;
-            const bIdx = orderIndex.get(b.addonId) ?? Infinity;
-            if (aIdx !== bIdx) return aIdx - bIdx;
-
             return a.addonId.localeCompare(b.addonId);
         });
 


### PR DESCRIPTION
## Summary

- nether_star の itemUse トリガーを廃止し、`router.beforeEvents.startup` 経由でカスタムコマンド `/kairo:addons` を登録
- アドオンリストのソート順を、同 state 内は activation order から addonId アルファベット順に変更

## Subcommands

| コマンド | 動作 |
|---|---|
| `list` | チャットにアドオン一覧を表示（active → inactive → unresolved、各グループ内アルファベット順） |
| `open` | 管理 UI フォームを開く |
| `enable <addonId> <version>` | 有効化 / バージョン切替 |
| `disable <addonId>` | 無効化（kairo 本体は不可） |
| `status <addonId>` | 指定アドオンの全バージョンと詳細状態をチャットに表示 |

## Test plan

- [ ] `/kairo:addons list` でアドオン一覧がチャットに表示されること
- [ ] `/kairo:addons open` で管理 UI が開くこと
- [ ] `/kairo:addons enable` / `disable` が正しく動作すること
- [ ] `/kairo:addons disable kairo` が拒否されること
- [ ] kairo が inactive のとき `"Kairo is inactive."` が表示されること